### PR TITLE
아이디 또는 메일 주소로 로그인할 수 있도록 허용

### DIFF
--- a/modules/member/member.admin.controller.php
+++ b/modules/member/member.admin.controller.php
@@ -557,7 +557,7 @@ class memberAdminController extends member
 			'</ruleset>';
 
 		$fields = array();
-		$trans = array('email_address'=>'email', 'user_id'=> 'userid');
+		$trans = array('email_address'=>'email', 'user_id'=> '');
 		$fields[] = sprintf('<field name="user_id" required="true" rule="%s"/>', $trans[$identifier]);
 		$fields[] = '<field name="password" required="true" />';
 

--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1670,7 +1670,7 @@ class memberController extends member
 		$args->ipaddress = $_SERVER['REMOTE_ADDR'];
 
 		// check identifier
-		if($config->identifier == 'email_address')
+		if($config->identifier == 'email_address' || strpos($user_id, '@') !== false)
 		{
 			// Get user_id information
 			$this->memberInfo = $oMemberModel->getMemberInfoByEmailAddress($user_id);


### PR DESCRIPTION
BJ람보 @qw5414 님이 작성하신 패치입니다.

https://www.xetown.com/lakepark/108186

이 패치 적용 후 회원가입 설정에서 로그인 계정을 "아이디"로 지정하고 저장하면, 앞으로는 로그인할 때 아이디를 써도 되고 메일 주소를 써도 됩니다.