### PR TITLE
코어를 쉬운설치로 업데이트하는 것을 금지

### DIFF
--- a/modules/autoinstall/autoinstall.admin.model.php
+++ b/modules/autoinstall/autoinstall.admin.model.php
@@ -205,7 +205,8 @@ class autoinstallAdminModel extends autoinstall
 
 			if($packageInfo->type == 'core')
 			{
-				$title = 'XpressEngine';
+				//$title = 'XpressEngine';
+				continue;
 			}
 			else
 			{


### PR DESCRIPTION
https://www.xetown.com/lakepark/11553

- XE타운 코어를 순정 코어로 업데이트하면 안되겠죠?
- 안 그래도 코어를 쉬운설치로 업데이트하다가 사이트가 맛이 가버리는 경우가 많습니다.
