### PR TITLE
Fix E_WARNING in DocumentController

### DIFF
--- a/modules/document/document.controller.php
+++ b/modules/document/document.controller.php
@@ -294,7 +294,7 @@ class documentController extends document
 			$oModuleModel = getModel('module');
 			$editor_config = $oModuleModel->getModuleConfig('editor');
 			
-			if(substr_compare($editor_config->sel_editor_colorset, 'nohtml', -6) === 0 && !$manual_inserted)
+			if(strlen($editor_config->sel_editor_colorset) >= 6 && substr_compare($editor_config->sel_editor_colorset, 'nohtml', -6) === 0 && !$manual_inserted)
 			{
 				$obj->content = preg_replace('/\r|\n/', '', nl2br(htmlspecialchars($obj->content, ENT_COMPAT | ENT_HTML401, 'UTF-8', false)));
 			}


### PR DESCRIPTION
    PHP Warning: substr_compare(): The start position cannot exceed initial string length