### PR TITLE
XE website 주소를 HTTPS 로 변경합니다.

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -72,12 +72,12 @@ else
 	/**
 	 * Location site
 	 */
-	define('_XE_LOCATION_SITE_', 'http://www.xpressengine.com/');
+	define('_XE_LOCATION_SITE_', 'https://www.xpressengine.com/');
 
 	/**
 	 * Download server
 	 */
-	define('_XE_DOWNLOAD_SERVER_', 'http://download.xpressengine.com/');
+	define('_XE_DOWNLOAD_SERVER_', 'https://download.xpressengine.com/');
 }
 
 /*

--- a/config/package.inc.php
+++ b/config/package.inc.php
@@ -3,5 +3,5 @@
 
 define('_XE_PACKAGE_', 'XE');
 define('_XE_LOCATION_', 'ko');
-define('_XE_LOCATION_SITE_', 'http://www.xpressengine.com/');
-define('_XE_DOWNLOAD_SERVER_', 'http://download.xpressengine.com/');
+define('_XE_LOCATION_SITE_', 'https://www.xpressengine.com/');
+define('_XE_DOWNLOAD_SERVER_', 'https://download.xpressengine.com/');

--- a/libs/PEAR.1.9.5/HTTP/Request.php
+++ b/libs/PEAR.1.9.5/HTTP/Request.php
@@ -27,7 +27,7 @@ class HTTP_Request extends HTTP_Request2
 	public function getResponseHeader() {
 		if($this->response)
 		{
-			return $this->response->getHeader();	
+			return $this->response->getHeader();
 		}
 	}
 

--- a/libs/ftp.class.php
+++ b/libs/ftp.class.php
@@ -53,7 +53,7 @@
         var $ftp_resp;
 
         /* Constractor */
-        function ftp()
+        function __construct()
         {
             $this->debug = false;
             $this->umask = 0022;

--- a/libs/tar.class.php
+++ b/libs/tar.class.php
@@ -76,7 +76,7 @@ class tar {
 
 
     // Class Constructor -- Does nothing...
-    function tar() {
+    function __construct() {
         return true;
     }
 

--- a/modules/autoinstall/autoinstall.admin.controller.php
+++ b/modules/autoinstall/autoinstall.admin.controller.php
@@ -71,7 +71,11 @@ class autoinstallAdminController extends autoinstall
 
 		$params["act"] = "getResourceapiUpdate";
 		$body = XmlGenerater::generate($params);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml");
+		$request_config = array(
+			'ssl_verify_peer' => FALSE,
+			'ssl_verify_host' => FALSE
+		);
+		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml = new XmlParser();
 		$xmlDoc = $xml->parse($buff);
 		$this->updateCategory($xmlDoc);

--- a/modules/autoinstall/autoinstall.admin.view.php
+++ b/modules/autoinstall/autoinstall.admin.view.php
@@ -310,7 +310,11 @@ class autoinstallAdminView extends autoinstall
 		$params["act"] = "getResourceapiPackages";
 		$params["package_srls"] = implode(",", array_keys($package_list));
 		$body = XmlGenerater::generate($params);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml");
+		$request_config = array(
+			'ssl_verify_peer' => FALSE,
+			'ssl_verify_host' => FALSE
+		);
+		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
 		$xmlDoc = $xml_lUpdate->parse($buff);
 		if($xmlDoc && $xmlDoc->response->packagelist->item)
@@ -401,7 +405,11 @@ class autoinstallAdminView extends autoinstall
 		$params = array();
 		$params["act"] = "getResourceapiLastupdate";
 		$body = XmlGenerater::generate($params);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml");
+		$request_config = array(
+			'ssl_verify_peer' => FALSE,
+			'ssl_verify_host' => FALSE
+		);
+		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
 		$lUpdateDoc = $xml_lUpdate->parse($buff);
 		$updateDate = $lUpdateDoc->response->updatedate->body;
@@ -547,7 +555,11 @@ class autoinstallAdminView extends autoinstall
 		$params["act"] = "getResourceapiPackages";
 		$params["package_srls"] = $package_srl;
 		$body = XmlGenerater::generate($params);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml");
+		$request_config = array(
+			'ssl_verify_peer' => FALSE,
+			'ssl_verify_host' => FALSE
+		);
+		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		$xml_lUpdate = new XmlParser();
 		$xmlDoc = $xml_lUpdate->parse($buff);
 		if($xmlDoc && $xmlDoc->response->packagelist->item)

--- a/modules/autoinstall/autoinstall.class.php
+++ b/modules/autoinstall/autoinstall.class.php
@@ -40,7 +40,11 @@ class XmlGenerater
 	function getXmlDoc(&$params)
 	{
 		$body = XmlGenerater::generate($params);
-		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml");
+		$request_config = array(
+			'ssl_verify_peer' => FALSE,
+			'ssl_verify_host' => FALSE
+		);
+		$buff = FileHandler::getRemoteResource(_XE_DOWNLOAD_SERVER_, $body, 3, "POST", "application/xml", array(), array(), array(), $request_config);
 		if(!$buff)
 		{
 			return;
@@ -133,6 +137,11 @@ class autoinstall extends ModuleObject
 			return TRUE;
 		}
 
+		// 2015.12.31 replace HTTP connection to HTTPS connection.
+		if($config->downloadServer !== _XE_DOWNLOAD_SERVER_)
+		{
+			return TRUE;
+		}
 		return FALSE;
 	}
 
@@ -179,6 +188,12 @@ class autoinstall extends ModuleObject
 			$oDB->addColumn('autoinstall_packages', 'have_instance', 'char', '1', 'N', TRUE);
 		}
 
+		// 2015.12.31 replace HTTP connection to HTTPS connection.
+		if($config->downloadServer !== _XE_DOWNLOAD_SERVER_)
+		{
+			$config->downloadServer = _XE_DOWNLOAD_SERVER_;
+			$oModuleController->insertModuleConfig('autoinstall', $config);
+		}
 		return new Object(0, 'success_updated');
 	}
 

--- a/modules/autoinstall/autoinstall.lib.php
+++ b/modules/autoinstall/autoinstall.lib.php
@@ -136,7 +136,11 @@ class ModuleInstaller
 		$postdata["path"] = $this->package->path;
 		$postdata["module"] = "resourceapi";
 		$postdata["act"] = "procResourceapiDownload";
-		$buff = FileHandler::getRemoteResource($this->base_url, NULL, 3, "POST", "application/x-www-form-urlencoded", array(), array(), $postdata);
+		$request_config = array(
+			'ssl_verify_peer' => FALSE,
+			'ssl_verify_host' => FALSE
+		);
+		$buff = FileHandler::getRemoteResource($this->base_url, NULL, 3, "POST", "application/x-www-form-urlencoded", array(), array(), $postdata, $request_config);
 		FileHandler::writeFile($this->download_file, $buff);
 	}
 


### PR DESCRIPTION
Support HTTPS connection from server to server and server to cilent.
다양한 환경에서 적용하기 위해서 SSL 호스트 검증은 하지 못할듯 합니다. -- curl 이라면 가능하다고는 하는데..

https://github.com/xetown/xe-core/pull/14 의 연장선입니다.
댓글 달아주신 @eugenee03 님 @kijin 님 감사합니다.

서버-서버 통신, 서버-클라이언트 통신에 HTTPS 가 적용됩니다.
다만, 한계가 있습니다. 인증서 검증을 하게 되면, 호환성 문제가 생기는 것 같아서 XE의 사양 안에서 해결했습니다.