### PR TITLE
관리자가 회원을 추가하거나 수정하는 경우 금지아이디를 확인하지 않음

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1988,7 +1988,7 @@ class memberController extends member
 		}
 
 		// Check if ID is prohibited
-		if($oMemberModel->isDeniedID($args->user_id))
+		if($logged_info->is_admin !== 'Y' && $oMemberModel->isDeniedID($args->user_id))
 		{
 			return new Object(-1,'denied_user_id');
 		}
@@ -2001,7 +2001,7 @@ class memberController extends member
 		}
 
 		// Check if nickname is prohibited
-		if($oMemberModel->isDeniedNickName($args->nick_name))
+		if($logged_info->is_admin !== 'Y' && $oMemberModel->isDeniedNickName($args->nick_name))
 		{
 			return new Object(-1,'denied_nick_name');
 		}
@@ -2014,7 +2014,7 @@ class memberController extends member
 		}
 
 		// Check managed Email Host
-		if($oMemberModel->isDeniedEmailHost($args->email_address))
+		if($logged_info->is_admin !== 'Y' && $oMemberModel->isDeniedEmailHost($args->email_address))
 		{
 			$config = $oMemberModel->getMemberConfig();
 			$emailhost_check = $config->emailhost_check;
@@ -2175,7 +2175,7 @@ class memberController extends member
 		$orgMemberInfo = $output->data;
 
 		// Check managed Email Host
-		if($oMemberModel->isDeniedEmailHost($args->email_address))
+		if($logged_info->is_admin !== 'Y' && $oMemberModel->isDeniedEmailHost($args->email_address))
 		{
 			$config = $oMemberModel->getMemberConfig();
 			$emailhost_check = $config->emailhost_check;
@@ -2212,7 +2212,7 @@ class memberController extends member
 		}
 
 		// Check if ID is prohibited
-		if($args->user_id && $oMemberModel->isDeniedID($args->user_id))
+		if($logged_info->is_admin !== 'Y' && $args->user_id && $oMemberModel->isDeniedID($args->user_id))
 		{
 			return new Object(-1,'denied_user_id');
 		}
@@ -2228,7 +2228,7 @@ class memberController extends member
 		}
 
 		// Check if nickname is prohibited
-		if($args->nick_name && $oMemberModel->isDeniedNickName($args->nick_name))
+		if($logged_info->is_admin !== 'Y' && $args->nick_name && $oMemberModel->isDeniedNickName($args->nick_name))
 		{
 			return new Object(-1, 'denied_nick_name');
 		}


### PR DESCRIPTION
xpressengine#1597 에서 발생한 버그인지, 아니면 그 전부터 있던 문제인지는 모르겠으나, 관리자가 회원을 추가하거나 수정하는 경우에도 금지아이디와 금지닉네임이 적용되어 수정이 불가능한 문제가 있었습니다.

예를 들어 XE를 설치하면서 관리자 아이디를 `admin`으로 지정한 경우, 금지아이디이므로 관리자 자신의 프로필조차 수정이 안 되는 문제가 발생합니다.

그래서 `insertMember` 및 `updateMemebr` 메소드에서 현재 로그인한 사용자가 관리자인 경우 아래의 제한을 적용하지 않도록 변경했습니다.

- 금지아이디
- 금지닉네임
- @misol 님이 xpressengine#1344 에서 추가한 이메일 호스트 제한
