### PR TITLE
유닛 테스트에서 Codeception을 로딩하는 방법 변경

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,18 @@ matrix:
   fast_finish: true
 sudo: false
 before_script:
-- travis_retry composer self-update
 - npm install -g grunt-cli
 - npm install
-- if [ $(phpenv version-name) != "5.3" ]; then composer install; fi
-- if [ $(phpenv version-name) != "5.3" ]; then mysql -e 'create database xe_test;'; fi
-- if [ $(phpenv version-name) != "5.3" ]; then echo "USE mysql;\nUPDATE user SET password=PASSWORD('travis')
-  WHERE user='travis';\nFLUSH PRIVILEGES;\n" | mysql -u root; fi
-- if [ $(phpenv version-name) != "5.3" ]; then php -S localhost:8000 & fi
+- mysql -e "CREATE DATABASE xe_test;"
+- echo "USE mysql;\nUPDATE user SET password=PASSWORD('travis') WHERE user='travis';\nFLUSH PRIVILEGES;\n" | mysql -u root
+- php -S localhost:8000 &
+- if [ $(phpenv version-name) == "5.3" ]; then touch codecept.phar; fi
+- if [ $(phpenv version-name) == "5.4" ]; then wget http://codeception.com/releases/2.0.16/codecept.phar; fi
+- if [ ! -f codecept.phar ]; then wget http://codeception.com/codecept.phar; fi
 script:
 - grunt lint
 - grunt minify
-- if [ $(phpenv version-name) != "5.3" ]; then ./vendor/bin/codecept build; fi
-- if [ $(phpenv version-name) != "5.3" ]; then ./vendor/bin/codecept run -d --fail-fast --env travis; fi
+- if [ -f codecept.phar ]; then php codecept.phar build; fi
+- if [ -f codecept.phar ]; then php codecept.phar run -d --fail-fast --env travis; fi
 notifications:
   email: false


### PR DESCRIPTION
Travis CI에서 유닛테스트 실행시 composer를 사용해서 codeception을 설치하기 때문에 1분 이상의 시간이 낭비되고, composer 관련 에러도 종종 발생합니다.

codeception 공식 사이트에서 최신 버전의 `codecept.phar`를 다운로드한 후 그대로 사용하도록 변경하여, 평균 3분 가량 걸리던 유닛 테스트 소요시간을 1분 30초 내외로 줄였습니다.

PHP 5.4에서는 [이 버그](https://github.com/Codeception/Codeception/issues/2124) 때문에 2.1.x 버전의 `codecept.phar`를 사용할 수 없으므로, 2.0.16 버전을 다운로드합니다.

PHP 5.3에서는 기존과 같이 codeception을 사용하지 않습니다.

HHVM에서는 여전히 `localhost:8000`에 접속할 수 없는 문제가 있습니다.