### PR TITLE
E_WARNING을 숨기지 않도록 변경

### DIFF
--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -8,4 +8,4 @@ settings:
     bootstrap: _bootstrap.php
     colors: true
     memory_limit: 1024M
-    error_level: "E_ALL & ~E_WARNING & ~E_STRICT & ~E_DEPRECATED & ~E_NOTICE"
+    error_level: "E_ALL & ~E_STRICT & ~E_DEPRECATED & ~E_NOTICE"

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -9,11 +9,11 @@
  */
 if(version_compare(PHP_VERSION, '5.4.0', '<'))
 {
-	@error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED ^ E_WARNING);
+	@error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED);
 }
 else
 {
-	@error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED ^ E_WARNING ^ E_STRICT);
+	@error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED ^ E_STRICT);
 }
 
 if(!defined('__XE__'))

--- a/tests/unit/classes/context/ContextTest.php
+++ b/tests/unit/classes/context/ContextTest.php
@@ -27,7 +27,8 @@ class ContextTest extends \Codeception\TestCase\Test
     public function testSetGetVars()
     {
         $this->assertEquals(Context::get('var1'), null);
-        context::set('var1', 'val1');
+        Context::getInstance()->context = new stdClass;
+        Context::set('var1', 'val1');
         $this->assertEquals(Context::get('var1'), 'val1');
 
         Context::set('var2', 'val2');

--- a/tests/unit/classes/validator/ValidatorTest.php
+++ b/tests/unit/classes/validator/ValidatorTest.php
@@ -10,7 +10,7 @@ class ValidatorTest extends \Codeception\TestCase\Test
     public function _before()
     {
         global $lang;
-
+        if(!$lang) $lang = new stdClass();
         $lang->filter = new stdClass();
         $lang->filter->isnull = 'isnull';
         $lang->filter->outofrange = 'outofrange';


### PR DESCRIPTION
@conory 님이 `E_WARNING`을 일으키는 부분을 대부분 수정하셨기에, 아예 `E_WARNING`을 숨기지 않는 것을 기본값으로 변경하고자 합니다. (XE타운 개발자분들은 이미 `config.user.inc.php`를 사용해서 에러 표시 설정을 바꿔서 쓰고 계실 거라고 생각합니다만... ^^)

유닛 테스트에서 `E_WARNING`을 일으키는 부분도 몇 군데 수정했습니다. 버그를 잡아내야 할 유닛 테스트가 워닝을 뿜어내다니 ㅠㅠ