### PR TITLE
유닛 테스트용 임시 파일들을 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ config.user.inc.php
 codeception.yml
 /tests/_output/
 /tests/*.suite.yml
+/tests/_support/InstallTester.php
+/tests/_support/UnitTester.php
+/tests/_support/_generated/
 
 /node_modules/
 /bower_components/


### PR DESCRIPTION
제목 그대로입니다. 개발 도중 로컬에서 codeception을 실행하면 자동으로 생성되는 임시 파일들이 불필요하게 커밋되는 것을 방지합니다. 유닛 테스트는 Travis CI에서만 실행하는 게 아니거든요 ^^