### PR TITLE
getMicroTime()을 microtime(true)로 변경

### DIFF
--- a/classes/db/DB.class.php
+++ b/classes/db/DB.class.php
@@ -382,7 +382,7 @@ class DB
 	{
 		$this->setError(0, 'success');
 		$this->query = $query;
-		$this->act_start = getMicroTime();
+		$this->act_start = microtime(true);
 		$this->elapsed_time = 0;
 	}
 
@@ -396,7 +396,7 @@ class DB
 		{
 			return;
 		}
-		$this->act_finish = getMicroTime();
+		$this->act_finish = microtime(true);
 		$elapsed_time = $this->act_finish - $this->act_start;
 		$this->elapsed_time = $elapsed_time;
 		$GLOBALS['__db_elapsed_time__'] += $elapsed_time;
@@ -1316,7 +1316,7 @@ class DB
 	function actDBClassStart()
 	{
 		$this->setError(0, 'success');
-		$this->act_dbclass_start = getMicroTime();
+		$this->act_dbclass_start = microtime(true);
 		$this->elapsed_dbclass_time = 0;
 	}
 
@@ -1330,7 +1330,7 @@ class DB
 		{
 			return;
 		}
-		$this->act_dbclass_finish = getMicroTime();
+		$this->act_dbclass_finish = microtime(true);
 		$elapsed_dbclass_time = $this->act_dbclass_finish - $this->act_dbclass_start;
 		$this->elapsed_dbclass_time = $elapsed_dbclass_time;
 		$GLOBALS['__dbclass_elapsed_time__'] += $elapsed_dbclass_time;

--- a/classes/display/DisplayHandler.class.php
+++ b/classes/display/DisplayHandler.class.php
@@ -142,7 +142,7 @@ class DisplayHandler extends Handler
 			return;
 		}
 
-		$end = getMicroTime();
+		$end = microtime(true);
 
 		// Firebug console output
 		if(__DEBUG_OUTPUT__ == 2 && version_compare(PHP_VERSION, '6.0.0') === -1)

--- a/classes/display/HTMLDisplayHandler.php
+++ b/classes/display/HTMLDisplayHandler.php
@@ -76,7 +76,7 @@ class HTMLDisplayHandler
 			{
 				if(__DEBUG__ == 3)
 				{
-					$start = getMicroTime();
+					$start = microtime(true);
 				}
 
 				Context::set('content', $output, false);
@@ -132,7 +132,7 @@ class HTMLDisplayHandler
 
 				if(__DEBUG__ == 3)
 				{
-					$GLOBALS['__layout_compile_elapsed__'] = getMicroTime() - $start;
+					$GLOBALS['__layout_compile_elapsed__'] = microtime(true) - $start;
 				}
 
 				if(stripos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== FALSE && (Context::get('_use_ssl') == 'optional' || Context::get('_use_ssl') == 'always'))
@@ -158,7 +158,7 @@ class HTMLDisplayHandler
 
 		if(__DEBUG__ == 3)
 		{
-			$start = getMicroTime();
+			$start = microtime(true);
 		}
 
 		// move <style ..></style> in body to the header
@@ -208,7 +208,7 @@ class HTMLDisplayHandler
 
 		if(__DEBUG__ == 3)
 		{
-			$GLOBALS['__trans_content_elapsed__'] = getMicroTime() - $start;
+			$GLOBALS['__trans_content_elapsed__'] = microtime(true) - $start;
 		}
 
 		// Remove unnecessary information

--- a/classes/module/ModuleHandler.class.php
+++ b/classes/module/ModuleHandler.class.php
@@ -1052,7 +1052,7 @@ class ModuleHandler extends Handler
 
 		if(__DEBUG__ == 3)
 		{
-			$start_time = getMicroTime();
+			$start_time = microtime(true);
 		}
 
 		$parent_module = $module;
@@ -1127,7 +1127,7 @@ class ModuleHandler extends Handler
 
 		if(__DEBUG__ == 3)
 		{
-			$GLOBALS['__elapsed_class_load__'] += getMicroTime() - $start_time;
+			$GLOBALS['__elapsed_class_load__'] += microtime(true) - $start_time;
 		}
 
 		// return the instance

--- a/classes/template/TemplateHandler.class.php
+++ b/classes/template/TemplateHandler.class.php
@@ -123,7 +123,7 @@ class TemplateHandler
 		// store the starting time for debug information
 		if(__DEBUG__ == 3)
 		{
-			$start = getMicroTime();
+			$start = microtime(true);
 		}
 
 		// initiation
@@ -184,7 +184,7 @@ class TemplateHandler
 		// store the ending time for debug information
 		if(__DEBUG__ == 3)
 		{
-			$GLOBALS['__template_elapsed__'] += getMicroTime() - $start;
+			$GLOBALS['__template_elapsed__'] += microtime(true) - $start;
 		}
 
 		return $output;

--- a/classes/xml/XmlParser.class.php
+++ b/classes/xml/XmlParser.class.php
@@ -91,7 +91,7 @@ class XmlParser
 		// Save the compile starting time for debugging
 		if(__DEBUG__ == 3)
 		{
-			$start = getMicroTime();
+			$start = microtime(true);
 		}
 
 		$this->lang = Context::getLangType();
@@ -143,7 +143,7 @@ class XmlParser
 		// Save compile starting time for debugging
 		if(__DEBUG__ == 3)
 		{
-			$GLOBALS['__xmlparse_elapsed__'] += getMicroTime() - $start;
+			$GLOBALS['__xmlparse_elapsed__'] += microtime(true) - $start;
 		}
 
 		return $output;

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -305,7 +305,7 @@ if(version_compare(PHP_VERSION, '5.3.0') >= 0)
 require(_XE_PATH_ . 'config/func.inc.php');
 
 if(__DEBUG__) {
-	define('__StartTime__', getMicroTime());
+	define('__StartTime__', microtime(true));
 }
 
 if(__DEBUG__) {
@@ -412,7 +412,7 @@ $GLOBALS['__xe_autoload_file_map'] = array_change_key_case(array(
 function __xe_autoload($class_name)
 {
 	if(__DEBUG__) {
-		$time_at = getMicroTime();
+		$time_at = microtime(true);
 	}
 
 	if(isset($GLOBALS['__xe_autoload_file_map'][strtolower($class_name)]))
@@ -436,7 +436,7 @@ function __xe_autoload($class_name)
 	}
 
 	if(__DEBUG__) {
-		$GLOBALS['__elapsed_class_load__'] += getMicroTime() - $time_at;
+		$GLOBALS['__elapsed_class_load__'] += microtime(true) - $time_at;
 	}
 }
 spl_autoload_register('__xe_autoload');

--- a/config/func.inc.php
+++ b/config/func.inc.php
@@ -971,8 +971,7 @@ function flushSlowlog()
  */
 function getMicroTime()
 {
-	list($time1, $time2) = explode(' ', microtime());
-	return (float) $time1 + (float) $time2;
+	return microtime(true);
 }
 
 /**

--- a/modules/widget/widget.controller.php
+++ b/modules/widget/widget.controller.php
@@ -442,7 +442,7 @@ class widgetController extends widget
 	function execute($widget, $args, $javascript_mode = false, $escaped = true)
 	{
 		// Save for debug run-time widget
-		if(__DEBUG__==3) $start = getMicroTime();
+		if(__DEBUG__==3) $start = microtime(true);
 		$before = microtime(true);
 		// urldecode the value of args haejum
 		$object_vars = get_object_vars($args);
@@ -641,7 +641,7 @@ class widgetController extends widget
 
 		$output = $widget_content_header . $widget_content_body . $widget_content_footer;
 		// Debug widget creation time information added to the results
-		if(__DEBUG__==3) $GLOBALS['__widget_excute_elapsed__'] += getMicroTime() - $start;
+		if(__DEBUG__==3) $GLOBALS['__widget_excute_elapsed__'] += microtime(true) - $start;
 
 		$after = microtime(true);
 


### PR DESCRIPTION
`microtime()` 함수에 `return_as_float` 파라미터가 추가된 게 언젠데 아직도 문자열 포맷으로 받아서 뜯었다 붙였다 하고 있네요. 모두 고치고, 서드파티 자료 호환성을 위해 코어의 `getMicroTime()` 함수도 기존 방식과 똑같은 결과를 반환하도록 했습니다.